### PR TITLE
Fix UnicodeDecodeError error on JSON load

### DIFF
--- a/save.py
+++ b/save.py
@@ -22,7 +22,7 @@ location = args.location[0]
 check_failures = args.failures
 
 # Open JSON
-with open(source) as f: data = json.load(f)
+with open(source, encoding="utf8") as f: data = json.load(f)
 
 # Get list
 activity = data["Activity"]


### PR DESCRIPTION
When having non-English letters in the JSON, the script throws a Unicode error.