### PR TITLE
Add support for downloading watched videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tiktok-save
 
-A Python utility for backing up your liked and bookmarked videos on TikTok. It will download the videos themselves as mp4 files, and associated metadata for each video as JSON.
+A Python utility for backing up your liked, bookmarked, and watched videos on TikTok. It will download the videos themselves as mp4 files, and associated metadata for each video as JSON.
 
 ## Before Starting
 
@@ -27,11 +27,12 @@ playwright is a headless browser that TikTok-Api uses to access TikTok - you mig
 
 ## Use
 
-Create a folder for your liked videos and a folder for your bookmarked videos. Then, from the `tiktok-save` directory, run:
+Create a folder for your liked, bookmarked, and watched videos. Then, from the `tiktok-save` directory, run:
 
 ```bash
 $ ./save.py liked user_data.json liked_videos_path
 $ ./save.py bookmarked user_data.json bookmarked_videos_path
+$ ./save.py watched user_data.json watched_videos_path
 ```
 
 Here `user_data.json` is the TikTok JSON export, assuming it's in the current directory - provide the path to it if not.
@@ -43,6 +44,7 @@ Any failures (where a video no longer exists for example) are saved in a `downlo
 - `<mode>`: Specify the type of videos to download. Options are:
   - `liked`: Download videos that you have liked.
   - `bookmarked`: Download videos that you have bookmarked.
+  - `watched`: Download videos that you have watched.
 
 - `<source>`: The path to the TikTok JSON file containing the video information.
 

--- a/save.py
+++ b/save.py
@@ -33,7 +33,7 @@ async def get_videos():
 
         # Parse script arguments
         parser = argparse.ArgumentParser(description="Save tiktok videos to disk.")
-        parser.add_argument("mode", type=str, nargs=1, choices=["liked", "bookmarked"], help="The type of video to download.")
+        parser.add_argument("mode", type=str, nargs=1, choices=["liked", "bookmarked", "watched"], help="The type of video to download.")
         parser.add_argument("source", type=str, nargs=1, help="The tiktok JSON file.")
         parser.add_argument("location", type=str, nargs=1, help="The folder to save to.")
         parser.add_argument("--failures", type=bool, nargs='?', const=True, default=False, help="Look at previous failures.")
@@ -58,8 +58,12 @@ async def get_videos():
 
         # Get list
         activity = data["Your Activity"]
-        videos = activity["Like List"]["ItemFavoriteList"] if mode == "liked" else \
-        activity["Favorite Videos"]["FavoriteVideoList"]
+        if mode == "liked":
+            videos = activity["LikeList"]["ItemFavoriteList"]
+        elif mode == "bookmarked":
+            videos = activity["Favorite Videos"]["FavoriteVideoList"]
+        else:
+            videos = activity["Watch History"]["VideoList"]
 
         # What videos are already accounted for?
         print("Checking for videos to download...")


### PR DESCRIPTION
TikTok user data JSON also has a list of watched videos, and the tool does not currently support downloading these. It's probably a lot more than most people want, but I did so added support for a `watched` parameter to `--mode` to download those:

```
(venv) adam@Adams-MacBook-Pro tiktok-save % ./save.py watched ~/Downloads/user_data_tiktok.json watched_videos
Checking for videos to download...
Failed again for https://www.tiktok.com/@/video/7585009802540027149/: 'video'
  0%|                                                                                              | 28/45622 [03:55<53:33:11,  4.23s/it]
```

Thanks for this project :) let me know what changes you might want before merging.